### PR TITLE
seller组件商家实景图宽度计算修改

### DIFF
--- a/src/components/seller/seller.vue
+++ b/src/components/seller/seller.vue
@@ -128,10 +128,6 @@
       },
       _initPics() {
         if (this.seller.pics) {
-          let picWidth = 120;
-          let margin = 6;
-          let width = (picWidth + margin) * this.seller.pics.length - margin;
-          this.$refs.picList.style.width = width + 'px';
           this.$nextTick(() => {
             if (!this.picScroll) {
               this.picScroll = new BScroll(this.$refs.picWrapper, {
@@ -279,6 +275,7 @@
         white-space: nowrap
         .pic-list
           font-size: 0
+          display: inline-block
           .pic-item
             display: inline-block
             margin-right: 6px


### PR DESCRIPTION
在老师课程的提问区看到有同学说这里不需要计算ul宽度，直接触发BFC就行，然后自己试了下，发现这里确实可以省略ul的宽度计算，但应该不是BFC的原因。
因为ul默认是块标签，所以宽度是由父元素决定的，不会被内容撑开，这里只要把ul的display设置成inline-block 或者设置浮动，就能让ul自适应内容宽度了。